### PR TITLE
refactored CMD config to use existing env vars if they exist

### DIFF
--- a/cms/cmd_builder.go
+++ b/cms/cmd_builder.go
@@ -13,12 +13,22 @@ import (
 	"github.com/pkg/errors"
 )
 
+var (
+	defaultDatasetAPIAuthToken = "FD0108EA-825D-411C-9B1D-41EF7727F465"
+	defaultDatasetAPIURL       = "http://localhost:22000"
+	defaultServiceAuthToken    = "fc4089e2e12937861377629b0cd96cf79298a4c5d329a2ebb96664c88df77b67"
+)
+
 // Build creates the Zebedee CMS directory structure
 func (b *Builder) GenerateCMSContent() error {
 	log.Event(nil, "generating CMS file structure and content", log.Data{
 		"root":       b.zebedeeDir,
 		"enable_cmd": b.enableCMD,
 	})
+
+	b.serviceAccountID = defaultServiceAuthToken
+	b.datasetAPIAuthToken = defaultDatasetAPIAuthToken
+	b.datasetAPIURL = defaultDatasetAPIURL
 
 	if err := b.cleanAndPrepare(b.rootDir); err != nil {
 		return err
@@ -47,9 +57,6 @@ func (b *Builder) GenerateCMSContent() error {
 	if err != nil {
 		return err
 	}
-
-	b.setDatasetAPIAuthToken()
-	b.datasetAPIURL = "http://localhost:22000"
 	return nil
 }
 
@@ -127,12 +134,7 @@ func (b *Builder) removeContentZipFromMaster() error {
 }
 
 func (b *Builder) createServiceAccount() error {
-	serviceAuthToken, err := getServiceTokenID()
-	if err != nil {
-		return err
-	}
 
-	b.serviceAccountID = serviceAuthToken
 	log.Event(nil, "generating CMD service account", log.Data{
 		"serviceAccountID": b.serviceAccountID,
 	})
@@ -152,37 +154,6 @@ func (b *Builder) createServiceAccount() error {
 		"serviceAccountID": b.serviceAccountID,
 	})
 	return nil
-}
-
-func getServiceTokenID() (string, error) {
-	if serviceAuthToken := os.Getenv(ServiceAuthTokenEnv); serviceAuthToken != "" {
-		log.Event(nil, fmt.Sprintf("found existing environment variable for %s using this id for generated service account", ServiceAuthTokenEnv))
-		return serviceAuthToken, nil
-	}
-
-	log.Event(nil, fmt.Sprintf("no existing environment variable %s found, generating new ID for generated service account", ServiceAuthTokenEnv))
-
-	return newRandomID(64), nil
-}
-
-func (b *Builder) setDatasetAPIAuthToken() {
-	if datasetAPIAuthToken := os.Getenv(DatasetAPIAuthTokenEnv); datasetAPIAuthToken != "" {
-		log.Event(nil, fmt.Sprintf("found existing environment variable for %s using this token value for generated run script", DatasetAPIAuthTokenEnv))
-		b.datasetAPIAuthToken = datasetAPIAuthToken
-	} else {
-		log.Event(nil, fmt.Sprintf("no existing environment variable %s found generating new token for generated run script", DatasetAPIAuthTokenEnv))
-		b.datasetAPIAuthToken = "FD0108EA-825D-411C-9B1D-41EF7727F465"
-	}
-}
-
-func (b *Builder) setDatasetAPIURL() {
-	if datasetAPIURL := os.Getenv(DatasetAPIURLEnv); datasetAPIURL != "" {
-		log.Event(nil, fmt.Sprintf("found existing environment variable for %q using this value for generated run script", DatasetAPIURLEnv))
-		b.datasetAPIURL = datasetAPIURL
-	} else {
-		log.Event(nil, fmt.Sprintf("no existing environment variable %s found generating new for generated run script", DatasetAPIURLEnv))
-		b.datasetAPIURL = "http://localhost:22000"
-	}
 }
 
 func (b *Builder) dirs() []string {

--- a/cms/models.go
+++ b/cms/models.go
@@ -58,11 +58,12 @@ type Builder struct {
 }
 
 type RunTemplate struct {
-	ZebedeeRoot         string
-	EnableDatasetImport bool
-	DatasetAPIURL       string
-	DatasetAPIAuthToken string
-	ServiceAuthToken    string
+	ZebedeeRoot              string
+	EnableDatasetPermissions bool
+	EnableDatasetImport      bool
+	DatasetAPIURL            string
+	DatasetAPIAuthToken      string
+	ServiceAuthToken         string
 }
 
 // New construct a new cmd.Builder
@@ -92,11 +93,12 @@ func New(root string, isCMD bool) (*Builder, error) {
 
 func (b *Builder) GetRunTemplate() *RunTemplate {
 	return &RunTemplate{
-		ZebedeeRoot:         b.rootDir,
-		EnableDatasetImport: b.enableCMD,
-		DatasetAPIURL:       b.datasetAPIURL,
-		DatasetAPIAuthToken: b.datasetAPIAuthToken,
-		ServiceAuthToken:    b.serviceAccountID,
+		ZebedeeRoot:              b.rootDir,
+		EnableDatasetImport:      b.enableCMD,
+		EnableDatasetPermissions: b.enableCMD,
+		DatasetAPIURL:            b.datasetAPIURL,
+		DatasetAPIAuthToken:      b.datasetAPIAuthToken,
+		ServiceAuthToken:         b.serviceAccountID,
 	}
 }
 

--- a/templates/run.cms.template.txt
+++ b/templates/run.cms.template.txt
@@ -7,7 +7,7 @@
 #############################################################
 
 # Sets the root Zebedee directory required to run Zebedee in publishing / CMS mode.
-export zebedee_root={{.ZebedeeRoot}}
+export zebedee_root="${zebedee_root:-{{.ZebedeeRoot}}}"
 
 # Zebedee runs by default on port :8082
 export PORT="${PORT:-8082}"
@@ -36,17 +36,20 @@ export FORMAT_LOGGING=true
 ###                               ###
 #####################################
 
-# feature flag to enabled/disabled the CMD features in Zebedee
-export ENABLE_DATASET_IMPORT={{.EnableDatasetImport}}
+# feature flag to enabled/disabled the CMD features in Zebedee default to enabled
+export ENABLE_DATASET_IMPORT="${ENABLE_DATASET_IMPORT:-{{.EnableDatasetImport}}}"
 
-# The dp-dataset-api url
-export DATASET_API_URL={{.DatasetAPIURL}}
+# Feature flag to enable CMD authorization features.
+export ENABLE_PERMISSIONS_AUTH="${ENABLE_PERMISSIONS_AUTH:-{{.EnableDatasetPermissions}}}"
 
-# The dp-dataset api auth token
-export DATASET_API_AUTH_TOKEN={{.DatasetAPIAuthToken}}
+# the dataset API url set default if not already set
+export DATASET_API_URL="${DATASET_API_URL:-{{.DatasetAPIURL}}}"
 
-# The service auth token
-export SERVICE_AUTH_TOKEN={{.ServiceAuthToken}}
+# the dataset API authentication token set default if not already set
+export DATASET_API_AUTH_TOKEN="${DATASET_API_AUTH_TOKEN:-{{.DatasetAPIAuthToken}}}"
+
+# Zebedee's authentication token for communicating with the dataset API set default if not already set
+export SERVICE_AUTH_TOKEN="${SERVICE_AUTH_TOKEN:-{{.ServiceAuthToken}}}"
 
 mvn clean package dependency:copy-dependencies -Dmaven.test.skip=true && \
 java $JAVA_OPTS \


### PR DESCRIPTION
 - Updated the generated `run-cms.sh` to use the standard default config values for 
   - `DATASET_API_URL`
   - `DATASET_API_AUTH_TOKEN`
   - `SERVICE_AUTH_TOKEN`
 - Default values will not be set if env vars already exist.
 - Added new `ENABLE_PERMISSIONS_AUTH` config with default value.