### PR TITLE
Feature/extend service accounts script

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### What
+
+Describe what you have changed and why.
+
+### How to review
+
+Describe the steps required to test the changes.
+
+### Who can review
+
+Describe who worked on the changes, so that other people can review.

--- a/scripts/service-accounts/README.md
+++ b/scripts/service-accounts/README.md
@@ -89,7 +89,7 @@ To generate service accounts for your local set up:
 git clone https://github.com/ONSdigital/dp-zebedee-content.git
 ```
 
-2. Move into the scripts dir
+1. Move into the scripts dir
 ```
 cd dp-zebedee-content/scripts/service-accounts
 ```
@@ -99,12 +99,36 @@ cd dp-zebedee-content/scripts/service-accounts
 go build -o generator
 ```
 
-7. Run the script: where `dir` is your `$zebedee_root` + `/zebedee/services` path 
- 
-```
-export HUMAN_LOG=true
+3. Set human readable logging:
 
-./generator -dir="<YOUR_ZEBEDEE_SERVICES_PATH>"
+`export HUMAN_LOG=true`
+
+4. The script has several flags some of which are optional, see table below:
+
+| flag      | mandatory | example                         | description                                                             |
+|-----------|-----------|---------------------------------|-------------------------------------------------------------------------|
+| dir       | yes       | <zebedee_root>/zebedee/services | The path to the location of your stored content for zebedee             |
+| replace   | no        | true                            | A boolean flag to clear out service auth tokens before regenerating     |
+| set-path  | no        | go/src/github.com/ONSdigital    | The path to where your digital publishing services exist                |
+| update-mk | no        | true                            | A boolean flag to update makefiles to contain unique SERVICE_AUTH_TOKEN |
+
+a) If you are planning to generate unique `SERVICE_AUTH_TOKEN`S for each service but do not want
+to update you Makefile for each service, run the following command:
+
+`./generator -dir=$zebedee_root>/zebedee/services`
+
+b) If you want to add any new `SERVICE_AUTH_TOKEN`'s to service Makefiles, run the following command:
+
+`./generator -dir=$zebedee_root>/zebedee/services -set-path="~/go/src/github.com/ONSdigital" -update-mk=true`
+
+For each new service auth token generated it will add the following line to that services Makefile:
+`export SERVICE_AUTH_TOKEN=<generated service auth token>` 
+
+c) If you want to replace all service auth tokens add the replace flag to either a or b options, like so:
+```
+a) ./generator -dir=$zebedee_root>/zebedee/services -replace=true
+
+b) ./generator -dir=$zebedee_root>/zebedee/services -set-path="~/go/src/github.com/ONSdigital" -update-mk=true -replace=true
 ```
 
 

--- a/scripts/service-accounts/generateServiceAccounts.go
+++ b/scripts/service-accounts/generateServiceAccounts.go
@@ -1,65 +1,50 @@
 package main
 
 import (
-	"bufio"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
-	"path/filepath"
-	"regexp"
 	"time"
 
+	"github.com/ONSdigital/dp-zebedee-content/scripts/service-accounts/service"
 	"github.com/ONSdigital/log.go/log"
 )
 
-const stringMatch string = "export GOARCH?=$(shell go env GOARCH)"
-
-var (
-	existingServiceAuthToken, _ = regexp.Compile("export SERVICE_AUTH_TOKEN=[a-zA-Z0-9]+")
-	serviceIDChars              = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
-	r                           *rand.Rand
-	services                    = []string{
-		"babbage",
-		"florence",
-		"zebedee",
-		"dp-frontend-router",
-		"dp-frontend-filter-dataset-controller",
-		"dp-frontend-renderer",
-		"dp-frontend-dataset-controller",
-		"dp-import-tracker",
-		"dp-dimension-extractor",
-		"dp-dimension-importer",
-		"dp-observation-extractor",
-		"dp-observation-importer",
-		"dp-import-api",
-		"dp-code-list-api",
-		"dp-dataset-api",
-		"dp-filter-api",
-		"dp-recipe-api",
-		"dp-code-list-api",
-		"dp-dataset-exporter",
-		"dp-hierarchy-api",
-		"dp-hierarchy-builder",
-		"dp-dataset-exporter",
-		"dp-dataset-exporter-xlsx",
-		"dp-search-builder",
-		"dp-search-api",
-		"dp-api-router",
-		"dp-download-service",
-		"dp-frontend-geography-controller",
-		"dp-identity-api",
-	}
-)
-
-type ServiceAccount struct {
-	ID   string `json:"-"`
-	Name string `json:"id,omitempty"`
+var services = []string{
+	"babbage",
+	"florence",
+	"zebedee",
+	"dp-frontend-router",
+	"dp-frontend-filter-dataset-controller",
+	"dp-frontend-renderer",
+	"dp-frontend-dataset-controller",
+	"dp-import-tracker",
+	"dp-dimension-extractor",
+	"dp-dimension-importer",
+	"dp-observation-extractor",
+	"dp-observation-importer",
+	"dp-import-api",
+	"dp-code-list-api",
+	"dp-dataset-api",
+	"dp-filter-api",
+	"dp-recipe-api",
+	"dp-code-list-api",
+	"dp-dataset-exporter",
+	"dp-hierarchy-api",
+	"dp-hierarchy-builder",
+	"dp-dataset-exporter",
+	"dp-dataset-exporter-xlsx",
+	"dp-search-builder",
+	"dp-search-api",
+	"dp-api-router",
+	"dp-download-service",
+	"dp-frontend-geography-controller",
+	"dp-identity-api",
 }
+
+var r *rand.Rand
 
 func init() {
 	s1 := rand.NewSource(time.Now().UnixNano())
@@ -70,16 +55,16 @@ func main() {
 	replaceDir := flag.Bool("replace", false, "the service account directory path to be replaced")
 	pathToServices := flag.String("set-path", "", "path to services")
 	serviceDir := flag.String("dir", "/zebedee/services", "the service account directory path")
-	updateMakeFiles := flag.Bool("update-mk", false, "an indicator to update repo makefiles to add service auth token, must be set to true or false, default value is false")
+	updateMakefiles := flag.Bool("update-mk", false, "an indicator to update repo makefiles to add service auth token, must be set to true or false, default value is false")
 
 	flag.Parse()
 
-	if err := createServiceDir(*serviceDir, *replaceDir); err != nil {
+	if err := service.CreateDirectory(*serviceDir, *replaceDir); err != nil {
 		log.Event(nil, "error checking service dir", log.Error(err))
 		os.Exit(1)
 	}
 
-	if *updateMakeFiles {
+	if *updateMakefiles {
 		// Check path to services is being set
 		if *pathToServices == "" {
 			err := errors.New("missing path to services")
@@ -88,7 +73,7 @@ func main() {
 		}
 	}
 
-	existingAccounts, err := loadExisting(*serviceDir)
+	existingAccounts, err := service.LoadExisting(*serviceDir)
 	if err != nil {
 		log.Event(nil, "error loading existing service accounts", log.Error(err))
 		os.Exit(1)
@@ -98,23 +83,23 @@ func main() {
 		log.Event(nil, "found existing service accounts skipped", log.Data{"existing_accounts": existingAccounts})
 	}
 
-	for _, service := range services {
-		logD := log.Data{"service": service}
+	for _, s := range services {
+		logD := log.Data{"service": s}
 
-		if _, ok := existingAccounts[service]; ok {
+		if _, ok := existingAccounts[s]; ok {
 			continue
 		}
 
-		acc, err := createServiceAccountJSON(*serviceDir, service)
+		acc, err := service.CreateJSONAccount(r, *serviceDir, s)
 		if err != nil {
 			log.Event(nil, "error creating service account", log.Error(err), logD)
 			os.Exit(1)
 		}
 
-		if *updateMakeFiles {
-			filePath := *pathToServices + "/" + service + "/Makefile"
+		if *updateMakefiles {
+			filePath := *pathToServices + "/" + s + "/Makefile"
 
-			if err := updateMakeFile(filePath, acc.ID); err != nil {
+			if err := service.UpdateMakefile(filePath, acc.ID); err != nil {
 				log.Event(nil, "unable to update makefile for service", log.Error(err), logD)
 			}
 		}
@@ -123,138 +108,4 @@ func main() {
 	}
 
 	log.Event(nil, "successfully created service accounts")
-}
-
-func updateMakeFile(filePath, serviceAuthToken string) error {
-	lines, err := file2lines(filePath)
-	if err != nil {
-		return err
-	}
-
-	fileContent := ""
-	for _, line := range lines {
-		if !existingServiceAuthToken.MatchString(line) {
-			fileContent += line + "\n"
-		}
-
-		if line == stringMatch {
-			fileContent += "export SERVICE_AUTH_TOKEN=" + serviceAuthToken + "\n"
-		}
-	}
-
-	return ioutil.WriteFile(filePath, []byte(fileContent), 0644)
-}
-
-func file2lines(filePath string) ([]string, error) {
-	f, err := os.Open(filePath)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-	return linesFromReader(f)
-}
-
-func linesFromReader(r io.Reader) ([]string, error) {
-	var lines []string
-	scanner := bufio.NewScanner(r)
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-
-	return lines, nil
-}
-
-func createServiceAccountJSON(path, service string) (*ServiceAccount, error) {
-	serviceAcc := &ServiceAccount{
-		ID:   newRandomID(64),
-		Name: service,
-	}
-
-	logD := log.Data{
-		"service": service,
-	}
-
-	jsonData, err := json.Marshal(serviceAcc)
-	if err != nil {
-		log.Event(nil, "error attempting to marshal service account to json", log.Error(err), logD)
-		return nil, err
-	}
-
-	p := filepath.Join(path, serviceAcc.ID+".json")
-	jsonFile, err := os.Create(p)
-	if err != nil {
-		log.Event(nil, "error creating service account json", log.Error(err), logD)
-		return nil, err
-	}
-	defer func() {
-		err := jsonFile.Close()
-		if err != nil {
-			log.Event(nil, "error closing service account json", log.Error(err), logD)
-		}
-	}()
-
-	_, err = jsonFile.Write(jsonData)
-	if err != nil {
-		log.Event(nil, "error writing service account to file", log.Error(err), logD)
-		return nil, err
-	}
-	return serviceAcc, nil
-}
-
-func createServiceDir(path string, replaceServiceDir bool) error {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		log.Event(nil, "services dir does not exist, now creating")
-		if err = os.MkdirAll(path, 0777); err != nil {
-			return err
-		}
-
-		return nil
-	}
-
-	if replaceServiceDir {
-		// Remove existing services directory
-		log.Event(nil, "removing directory")
-		os.RemoveAll(path + "/")
-	}
-
-	log.Event(nil, "services dir does not exist, now creating")
-	if err := os.MkdirAll(path, 0777); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func loadExisting(servicePath string) (map[string]*ServiceAccount, error) {
-	results := make(map[string]*ServiceAccount, 0)
-
-	err := filepath.Walk(servicePath, func(path string, info os.FileInfo, err error) error {
-		if filepath.Ext(path) == ".json" {
-			b, err := ioutil.ReadFile(path)
-			if err != nil {
-				return err
-			}
-
-			var acc ServiceAccount
-			if err := json.Unmarshal(b, &acc); err != nil {
-				return err
-			}
-			results[acc.Name] = &acc
-		}
-		return nil
-	})
-
-	return results, err
-}
-
-func newRandomID(size int) string {
-	id := ""
-	for len(id) < size {
-		id += string(serviceIDChars[r.Intn(len(serviceIDChars))])
-	}
-
-	return id
 }

--- a/scripts/service-accounts/service/service.go
+++ b/scripts/service-accounts/service/service.go
@@ -1,0 +1,116 @@
+package service
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+
+	"github.com/ONSdigital/log.go/log"
+)
+
+var (
+	serviceIDChars = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+)
+
+// Account represents data structure stored against a service
+type Account struct {
+	ID   string `json:"-"`
+	Name string `json:"id,omitempty"`
+}
+
+// CreateDirectory represents the creation `services` directory in chosen path
+func CreateDirectory(path string, replaceServiceDir bool) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		log.Event(nil, "services dir does not exist, now creating")
+		if err = os.MkdirAll(path, 0777); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	if replaceServiceDir {
+		// Remove existing services directory before recreating
+		log.Event(nil, "removing directory")
+		os.RemoveAll(path + "/")
+	}
+
+	log.Event(nil, "services dir does not exist, now creating")
+	if err := os.MkdirAll(path, 0777); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LoadExisting represents building a list of existing service accounts
+func LoadExisting(servicePath string) (map[string]*Account, error) {
+	results := make(map[string]*Account, 0)
+
+	err := filepath.Walk(servicePath, func(path string, info os.FileInfo, err error) error {
+		if filepath.Ext(path) == ".json" {
+			b, err := ioutil.ReadFile(path)
+			if err != nil {
+				return err
+			}
+
+			var acc Account
+			if err := json.Unmarshal(b, &acc); err != nil {
+				return err
+			}
+			results[acc.Name] = &acc
+		}
+		return nil
+	})
+
+	return results, err
+}
+
+// CreateJSONAccount represents the creation of a service account (incl. token)
+func CreateJSONAccount(r *rand.Rand, path, service string) (*Account, error) {
+	serviceAcc := &Account{
+		ID:   newRandomID(r, 64),
+		Name: service,
+	}
+
+	logD := log.Data{
+		"service": service,
+	}
+
+	jsonData, err := json.Marshal(serviceAcc)
+	if err != nil {
+		log.Event(nil, "error attempting to marshal service account to json", log.Error(err), logD)
+		return nil, err
+	}
+
+	p := filepath.Join(path, serviceAcc.ID+".json")
+	jsonFile, err := os.Create(p)
+	if err != nil {
+		log.Event(nil, "error creating service account json", log.Error(err), logD)
+		return nil, err
+	}
+	defer func() {
+		err := jsonFile.Close()
+		if err != nil {
+			log.Event(nil, "error closing service account json", log.Error(err), logD)
+		}
+	}()
+
+	_, err = jsonFile.Write(jsonData)
+	if err != nil {
+		log.Event(nil, "error writing service account to file", log.Error(err), logD)
+		return nil, err
+	}
+	return serviceAcc, nil
+}
+
+func newRandomID(r *rand.Rand, size int) string {
+	id := ""
+	for len(id) < size {
+		id += string(serviceIDChars[r.Intn(len(serviceIDChars))])
+	}
+
+	return id
+}

--- a/scripts/service-accounts/service/updateMakefile.go
+++ b/scripts/service-accounts/service/updateMakefile.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"bufio"
+	"io"
+	"io/ioutil"
+	"os"
+	"regexp"
+)
+
+const stringMatch string = "export GOARCH?=$(shell go env GOARCH)"
+
+var existingServiceAuthToken, _ = regexp.Compile("export SERVICE_AUTH_TOKEN=[a-zA-Z0-9]+")
+
+// UpdateMakefile adds environment variable SERVICE_AUTH_TOKEN
+// to a services Makefile
+func UpdateMakefile(filePath, serviceAuthToken string) error {
+	lines, err := file2lines(filePath)
+	if err != nil {
+		return err
+	}
+
+	fileContent := ""
+	for _, line := range lines {
+		if !existingServiceAuthToken.MatchString(line) {
+			fileContent += line + "\n"
+		}
+
+		if line == stringMatch {
+			fileContent += "export SERVICE_AUTH_TOKEN=" + serviceAuthToken + "\n"
+		}
+	}
+
+	return ioutil.WriteFile(filePath, []byte(fileContent), 0644)
+}
+
+func file2lines(filePath string) ([]string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return linesFromReader(f)
+}
+
+func linesFromReader(r io.Reader) ([]string, error) {
+	var lines []string
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return lines, nil
+}


### PR DESCRIPTION
### What

Extend script to handle recreation of service accounts, as well adding the service auth token to each service Makefile (optional using flags)

### How to review

Check script works for you by following the README.md, check unique service auth tokens are added to your go services

### Who can review

Anyone