### PR TITLE
add transactions folder to content builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # Created by .ignore support plugin (hsz.mobi)
 .idea*
 generated/run-cms.sh
+zebContent
+.DS_Store

--- a/cms/cmd_builder.go
+++ b/cms/cmd_builder.go
@@ -166,6 +166,7 @@ func (b *Builder) dirs() []string {
 		b.sessionsDir,
 		b.permissionsDir,
 		b.teamsDir,
+		b.transactionsDir,
 		b.launchPadDir,
 		b.appKeysDir,
 		b.servicesDir,

--- a/cms/models.go
+++ b/cms/models.go
@@ -17,6 +17,7 @@ const (
 	Services               = "services"
 	Permissions            = "permissions"
 	Teams                  = "teams"
+	Transactions           = "transactions"
 	LaunchPad              = "launchpad"
 	AppKeys                = "application-keys"
 	defaultContentZip      = "default-content.zip"
@@ -49,6 +50,7 @@ type Builder struct {
 	servicesDir         string
 	permissionsDir      string
 	teamsDir            string
+	transactionsDir     string
 	launchPadDir        string
 	appKeysDir          string
 	enableCMD           bool
@@ -81,6 +83,7 @@ func New(root string, isCMD bool) (*Builder, error) {
 		servicesDir:         filepath.Join(zebedeeDir, Services),
 		permissionsDir:      filepath.Join(zebedeeDir, Permissions),
 		teamsDir:            filepath.Join(zebedeeDir, Teams),
+		transactionsDir:     filepath.Join(zebedeeDir, Transactions),
 		launchPadDir:        filepath.Join(zebedeeDir, LaunchPad),
 		appKeysDir:          filepath.Join(zebedeeDir, AppKeys),
 		enableCMD:           isCMD,


### PR DESCRIPTION
### What

The transactions directory required by The Train was not being created. This adds the directory to the builder.

I've also updated the `.gitignore` to ignore the zebContent file that's built, and `.DS_Store`

### How to review

- Check code makes sense and nothing in the build process is missed
- Run the tool and see if the transactions directory is included in the content folder

### Who can review

Anyone but me
