### PR TITLE
update run-cms.sh template with Dossindex.skip

### DIFF
--- a/templates/run.cms.template.txt
+++ b/templates/run.cms.template.txt
@@ -54,7 +54,7 @@ export SERVICE_AUTH_TOKEN="${SERVICE_AUTH_TOKEN:-{{.ServiceAuthToken}}}"
 #
 # Compile and run
 #
-mvn clean package dependency:copy-dependencies -Dmaven.test.skip=true && \
+mvn clean package dependency:copy-dependencies -Dmaven.test.skip=true -Dossindex.skip=true && \
 java $JAVA_OPTS \
  -Dlogback.configurationFile=zebedee-cms/target/classes/logback.xml \
  -Ddb_audit_url=$db_audit_url \


### PR DESCRIPTION
Update the run-cms.sh template with Dossindex.skip=true

Before, it was implemented in the run.sh and run-reader.sh but not in run-cms.sh