### PR TITLE
Fix incorrect zebedee_root being output and add ability to fall back on zebedee_root env var if flag not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,22 @@ Command line tool generating default content required to run Zebedee CMS.
 
 ![Alt text](preview.png?raw=true "Optional Title")
 
-### Prerequisites
+## Prerequisites
+
 - Go version >= `1.15`
 - Access to the AWS dev account
 - Your aws config/credentials files will need entries for the `[default]` profile:
 
-Example:
-`.aws/config`
-```bash
+Example: `.aws/config`
+
+```ini
   [default]
-  region = eu-west-1
+  region=eu-west-1
   ```
+
 Example: `.aws/credentials`
-```
+
+```ini
 ...
 [default]
 aws_access_key_id=...
@@ -28,51 +31,60 @@ aws_secret_access_key=...
 region=eu-west-1
 ...
 ```
-### Getting started
+
+## Getting started
+
 dp-zebedee-content is a Go Module so needs to be cloned to a directory **outside of your $GOPATH**
 
-```
+```shell
 git clone git@github.com:ONSdigital/dp-zebedee-content.git
 ```
 
 ### Install
-```
+
+```shell
 make install
 ```
 
 ### Run
-```bash
+
+```shell
 dp-zebedee-content generate -c=~/path_where_you_want_the_content_to_be_generated
 ```
 
-See [Flags](#Flags) for further details. 
+See [Flags](#Flags) for further details.
 
 The `generate` command will:
- - Generate the directory structure required by Zebedee-CMS.
- - Populate the CMS with default content.
- - Generates default user, teams, permissions and service token content.
 
-**Note** It's safe to run the `generate` command multiple times. Doing so will overwrite any previously generated 
-content and reset the CMS content, users, teams etc. to the default state.  
+- Generate the directory structure required by Zebedee-CMS.
+- Populate the CMS with default content.
+- Generates default user, teams, permissions and service token content.
+
+**Note** It's safe to run the `generate` command multiple times. Doing so will overwrite any previously generated
+content and reset the CMS content, users, teams etc. to the default state.
 
 ### Flags
-| Flag         | Description                                                                                 | Example                                                             |
-| ------------ |---------------------------------------------------------------------------------------------| ------------------------------------------------------------------- |
-| h / help     | Display the help menu.                                                                      |                                                                     |
-| c / content  | The output directory the generated content will be written - this can be anywhere you like. | `~/Desktop/zebedee-content/generated` (`~` prefix will be expanded) |
 
-Once you have run generator add the output `zebedee_root` and `SERVICE_AUTH_TOKEN` values to your ENV vars. 
+| Flag        | Description                                                                                                                                                 | Example                                                              |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| h / help    | Display the help menu.                                                                                                                                      |                                                                      |
+| c / content | The output directory the generated content will be written - this can be anywhere you like. If unset, the `zebedee_root` env var will be attempted instead. | `~/Desktop/zebedee-content/generated` (`~` prefix will be expanded). |
+
+Once you have run generator add the output `zebedee_root` and `SERVICE_AUTH_TOKEN` values to your ENV vars.
 You should now have the required directories, content and configurations to run a local copy of Zebedee CMS.
 
-### Help/Issues
+## Help/Issues
+
 If you experience any problems with this tool please speak to a member of the dev team. If you believe there is a defect or issue with the code you can either:
+
 - Raise a [github issue][2].
 - Open pull request.
 
-Please be sure to provide a description of the problem and steps to recreate. 
+Please be sure to provide a description of the problem and steps to recreate.
 
 Kind regards
-The Dev team  
+
+The Dev team
 
 [1]: https://github.com/kardianos/govendor
 [2]: https://github.com/ONSdigital/dp-zebedee-content/issues

--- a/cms/cms.go
+++ b/cms/cms.go
@@ -88,7 +88,7 @@ func Setup(cmsRootDir string, downloader Downloader) error {
 	log.Info(":exclamation: Add the following to your env vars if they do not already exist :exclamation:")
 
 	color.Yellow("\n\texport SERVICE_AUTH_TOKEN=%s", serviceAuthToken)
-	color.Yellow("\texport zebedee_root=%s\n\n", zebedeeDir)
+	color.Yellow("\texport zebedee_root=%s\n\n", cmsRootDir)
 
 	log.Info("restart zebedee if already running and ensure the correct %q configuration is being applied (full app configuration is logged on start up)", "zebedee_root")
 	log.Info("set up CMS content completed successfully :tada::rocket:")


### PR DESCRIPTION
The env var being output as the one to set in your profile is incorrect as it was adding the `/zebedee` onto the end. Zebedee itself will also add `/zebedee` resulting in a path of `/zebedee/zebedee`.

Also adds the ability to fall back on the `zebedee_root` env var if the `content/c` command line flag is not set. This is a convenience feature for those attempting to quickly reset their local content.

The README has also been tidied up a little.