### PR TITLE
Move generated folders one level down

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ cli
 .vscode/launch.json
 
 # Files created by script
-/publishing/*
-/web/*
+/generated/*

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,18 @@ SRC_DIR          = src
 SRC_CONTENT_DIR  = content
 SRC_SERVICES_DIR = services
 
+# Generated content directory
+GENERATED_ROOT_DIR = generated
+
 # Publishing dirs
 # PUB_ROOT_DIR is $zebedee_root + the extra zebedee subdir that zebedee requires
-PUB_ROOT_DIR       = publishing/zebedee
+PUB_ROOT_DIR       = $(GENERATED_ROOT_DIR)/publishing/zebedee
 PUB_MASTER_DIR     = master
 PUB_SERVICES_DIR   = services
 PUB_DIRS_TO_CREATE = $(PUB_MASTER_DIR) $(PUB_SERVICES_DIR) application-keys collections keyring launchpad permissions publishing-log transactions
 
 # Web dirs
-WEB_ROOT_DIR       = web
+WEB_ROOT_DIR       = $(GENERATED_ROOT_DIR)/web
 WEB_SITE_DIR       = site
 WEB_DIRS_TO_CREATE = $(WEB_SITE_DIR) transactions
 
@@ -28,4 +31,4 @@ init: clean
 
 .PHONY: clean
 clean:
-	rm -rf web/ publishing/
+	rm -rf $(GENERATED_ROOT_DIR)


### PR DESCRIPTION
Move publishing and web one level down to make it clear they're part of a generated content folder. 